### PR TITLE
remove const from type index ptr

### DIFF
--- a/include/static_type_info/type_index.h
+++ b/include/static_type_info/type_index.h
@@ -15,8 +15,8 @@
 namespace static_type_info {
 
   namespace detail {
-    template <typename T> struct IDGenerator { static const void* const id; };
-    template <typename T> const void* const IDGenerator<T>::id = nullptr;
+    template <typename T> struct IDGenerator { static const void* id; };
+    template <typename T> const void* IDGenerator<T>::id = nullptr;
   }  // namespace detail
 
   using TypeIndex = decltype(&detail::IDGenerator<void>::id);


### PR DESCRIPTION
I have encountered two issues with the IDGenerator<T>::id being const.
1. There is (probably) a bug in vs studio (tested on 16.11.9). With this const getTypeIndex() produces the same address for all types when whole program optimization (/GL) and Fast Link Time Code Generation (/LTCG:incremental) are enabled while debug information is disabled. With these options the tests fail even so the static_assert statements remain true. Without the const this broken optimization does not take place.
2. In some contexts (e.g. key of a hash map) the immutability of static_type_info::TypeIndex can cause issues which makes it necessary to manually remove it:
`using TypeIndex = std::remove_const_t<static_type_info::TypeIndex>; `

Unless I am missing something the easiest fix appears to be to just remove it.
